### PR TITLE
Add Gershwin ISO to Unstable pipeline for jenkins

### DIFF
--- a/pipelines/build-unstable-iso.jenkins
+++ b/pipelines/build-unstable-iso.jenkins
@@ -27,5 +27,18 @@ pipeline {
         archiveArtifacts artifacts: "artifacts/**", fingerprint: false
       }
     }
+    stage('Build GhostBSD Gershwin from unstable packages') {
+      steps {
+        sh "chflags -R noschg /usr/local/ghostbsd-build/ || true"
+        sh "rm -rf /usr/local/ghostbsd-build || true"
+        sh "rm -rf ghostbsd-build || true"
+        sh "rm -rf artifacts || true"
+        sh "git clone --single-branch --depth=1 -b master https://github.com/ghostbsd/ghostbsd-build.git"
+        sh "cd ghostbsd-build ; ./build.sh -d gershwin -b unstable"
+        sh "mkdir -p artifacts"
+        sh "cp /usr/local/ghostbsd-build/iso/* artifacts/"
+        archiveArtifacts artifacts: "artifacts/**", fingerprint: false
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add Gershwin ISO to the unstable Jenkins build pipeline