### PR TITLE
Adding pycharm and waterfox to useful_packages

### DIFF
--- a/tests/useful_packages
+++ b/tests/useful_packages
@@ -7,10 +7,12 @@ linux-sublime-text4
 mtr-nox11
 nextcloudclient
 obs-studio
+pycharm
 screen
 signal-desktop
 telegram-desktop
 terminator
 tmux
 vscode
+waterfox
 wget


### PR DESCRIPTION
## Summary by Sourcery

Add PyCharm and Waterfox to the useful_packages test list

Enhancements:
- Add PyCharm to tests/useful_packages
- Add Waterfox to tests/useful_packages